### PR TITLE
drop gradle version to 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
According to https://search.maven.org/artifact/com.android.tools.build/gradle, the highest hosted version of the com.android.tools.build.gradle maven package is 2.3.0, not 2.3.3