### PR TITLE
support content scheme

### DIFF
--- a/android/src/main/java/com/existfragger/rnimagesize/RNImageSizeModule.java
+++ b/android/src/main/java/com/existfragger/rnimagesize/RNImageSizeModule.java
@@ -1,9 +1,11 @@
 package com.existfragger.rnimagesize;
 
+import android.content.ContentResolver;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
 import android.net.Uri;
+import android.os.Build;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -18,8 +20,11 @@ import java.net.URL;
 public class RNImageSizeModule extends NativeImageSizeModuleSpec {
     public static final String NAME = "RNImageSize";
 
+    private ReactApplicationContext reactContext;
+
     public RNImageSizeModule(final ReactApplicationContext reactContext) {
         super(reactContext);
+        this.reactContext = reactContext;
     }
 
     @Override
@@ -28,30 +33,47 @@ public class RNImageSizeModule extends NativeImageSizeModuleSpec {
             public void run() {
                 try {
                     Uri u = Uri.parse(uri);
+                    String scheme = u.getScheme();
                     BitmapFactory.Options options = new BitmapFactory.Options();
+                    ExifInterface exifInterface = null;
                     options.inJustDecodeBounds = true;
 
                     int height = 0;
                     int width = 0;
                     int rotation = 0;
 
-                    if (uri.startsWith("file://")) {
-                        BitmapFactory.decodeFile(u.getPath(), options);
-                        ExifInterface exifInterface = new ExifInterface(u.getPath());
-                        int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
-                        if (orientation == ExifInterface.ORIENTATION_ROTATE_90)
-                        rotation = 90;
-                        else if (orientation == ExifInterface.ORIENTATION_ROTATE_180)
-                        rotation = 180;
-                        else if (orientation == ExifInterface.ORIENTATION_ROTATE_270)
-                        rotation = 270;
-                        height = options.outHeight;
-                        width = options.outWidth;
+                    if (ContentResolver.SCHEME_FILE.equals(scheme) ||
+                            ContentResolver.SCHEME_CONTENT.equals(scheme) ||
+                            ContentResolver.SCHEME_ANDROID_RESOURCE.equals(scheme)) {
+                        ContentResolver contentResolver = reactContext.getContentResolver();
+                        BitmapFactory.decodeStream(contentResolver.openInputStream(u), null,
+                                                                             options);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                            exifInterface =
+                                    new ExifInterface(contentResolver.openInputStream(u));
+                        } else if (ContentResolver.SCHEME_FILE.equals(scheme)) {
+                            exifInterface = new ExifInterface(u.getPath());
+                        }
                     } else {
                         URL url = new URL(uri);
-                        Bitmap bitmap = BitmapFactory.decodeStream((InputStream) url.getContent());
-                        height = bitmap.getHeight();
-                        width = bitmap.getWidth();
+                        BitmapFactory.decodeStream(url.openStream(), null, options);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                            exifInterface = new ExifInterface(url.openStream());
+                        }
+                    }
+
+                    height = options.outHeight;
+                    width = options.outWidth;
+
+                    if (exifInterface != null) {
+                        int orientation =
+                                exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
+                        if (orientation == ExifInterface.ORIENTATION_ROTATE_90)
+                            rotation = 90;
+                        else if (orientation == ExifInterface.ORIENTATION_ROTATE_180)
+                            rotation = 180;
+                        else if (orientation == ExifInterface.ORIENTATION_ROTATE_270)
+                            rotation = 270;
                     }
 
                     WritableMap map = Arguments.createMap();


### PR DESCRIPTION
cc @roryabraham (X-ref: https://github.com/Expensify/App/pull/48370)

This PR adds support for `content://` scheme files. Luckily this was already supported upstream, I just copied the implementation 