### PR TITLE
fix: remove failing `jcenter`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
I got this error when trying to build android in E/App after upgrading the project to React Native 0.83

```shell
* What went wrong:
│  A problem occurred evaluating project ':react-native-image-size'.
│  > Could not find method jcenter() for arguments [] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.
```

it looks like `jcenter` is no longer needed and we can safely remove it